### PR TITLE
Prepare a PR for https://github.com/arrbee/diff-match-patch-c/issues/5

### DIFF
--- a/src/dmp.c
+++ b/src/dmp.c
@@ -373,7 +373,7 @@ static int diff_bisect(
 static int diff_cleanup_merge(dmp_diff *diff, dmp_range *list)
 {
 	dmp_pool *pool = &diff->pool;
-	int i, before, common, changes;
+	int i, j, before, common, changes;
 	int count_delete, count_insert, len_delete, len_insert;
 	dmp_node *ins = NULL, *del = NULL, *last = NULL, *node, *next;
 
@@ -394,8 +394,9 @@ static int diff_cleanup_merge(dmp_diff *diff, dmp_range *list)
 	 * that can be extracted
 	 */
 
-	for (i = list->start; i != -1; i = node->next) {
+	for (i = list->start; i != -1; i = j) {
 		node = dmp_node_at(pool, i);
+        j = node->next;
 
 		switch (node->op) {
 		case DMP_DIFF_INSERT:

--- a/test/dmp_test.c
+++ b/test/dmp_test.c
@@ -209,6 +209,12 @@ void test_diff_0(void)
 	dmp_diff_print_raw(stderr, diff);
 	expect_diff_stat(diff, 1, 1, 1, 0x5); /* 0101 */
 	dmp_diff_free(diff);
+
+    dmp_diff_from_strs(&diff, NULL, "a\nbcde\n\n", "A\nbcdefghijklmnopqrst\n\n");
+    assert(diff != NULL);
+    dmp_diff_print_raw(stderr, diff);
+    expect_diff_stat(diff, 1, 2, 2, 0x1a); /* 11010 */
+    dmp_diff_free(diff);
 }
 
 


### PR DESCRIPTION
OK, Here is a fix for the problem :-)

The problem was caused by the first loop in diff_cleanup_merge().
'i' was used as the position for the current element, and updated to node->next at the end of each loop iteration.
HOWEVER, some of the loop iterations have unallocated the current node pointed by 'i', effectively setting its 'next' element to point to the free store, thereby corrupting 'i'.
The solution was to calculate the next 'i' and saving it at the beginning of the loop iteration.
